### PR TITLE
backend test check-in

### DIFF
--- a/backend/__tests__/calculate.test.ts
+++ b/backend/__tests__/calculate.test.ts
@@ -3,9 +3,12 @@ import {
   MachineType,
   WeldingRobotPart,
   partInfo,
+  PaintingStationPart,
+  AssemblyLinePart,
+  QualityControlStationPart,
 } from '../../native-app/data/types';
 
-describe('calculatePartHealth', () => {
+describe('calculatePartHealth for WeldingRobot', () => {
   it('calculates part health correctly', () => {
     const machineName: MachineType = MachineType.WeldingRobot;
     const part: partInfo = {name: WeldingRobotPart.ErrorRate, value: 0.5};
@@ -16,7 +19,7 @@ describe('calculatePartHealth', () => {
   });
 });
 
-describe('calculateMachineHealth', () => {
+describe('calculateMachineHealth for WeldingRobot', () => {
   it('calculates machine health correctly', () => {
     const machineName: MachineType = MachineType.WeldingRobot;
     const parts = [
@@ -30,6 +33,89 @@ describe('calculateMachineHealth', () => {
       {name: WeldingRobotPart.CoolingEfficiency, value: 85.0},
     ];
     const expectedHealth = 76.70138888888889;
+
+    const result = calculateMachineHealth(machineName, parts);
+    expect(result).toBe(expectedHealth);
+  });
+});
+
+describe('calculatePartHealth for PaintingStation', () => {
+  it('calculates part health correctly', () => {
+    const machineName: MachineType = MachineType.PaintingStation;
+    const part: partInfo = {name: PaintingStationPart.FlowRate, value: 25};
+    const expectedHealth = 75;
+
+    const result = calculatePartHealth(machineName, part);
+    expect(result).toBe(expectedHealth);
+  });
+});
+
+describe('calculateMachineHealth for PaintingStation', () => {
+  it('calculates machine health correctly', () => {
+    const machineName: MachineType = MachineType.PaintingStation;
+    const parts = [
+      {name: PaintingStationPart.FlowRate, value: 0.5},
+      {name: PaintingStationPart.ColorConsistency, value: 4.0},
+      {name: PaintingStationPart.NozzleCondition, value: 0.8},
+      {name: PaintingStationPart.Pressure, value: 12.0}
+    ];
+    const expectedHealth = 22.5;
+
+    const result = calculateMachineHealth(machineName, parts);
+    expect(result).toBe(expectedHealth);
+  });
+});
+
+describe('calculatePartHealth for AssemblyLine', () => {
+  it('calculates part health correctly', () => {
+    const machineName: MachineType = MachineType.AssemblyLine;
+    const part: partInfo = {name: AssemblyLinePart.BeltSpeed, value: 1.5};
+    const expectedHealth = 75;
+
+    const result = calculatePartHealth(machineName, part);
+    expect(result).toBe(expectedHealth);
+  });
+});
+
+describe('calculateMachineHealth for AssemblyLine', () => {
+  it('calculates machine health correctly', () => {
+    const machineName: MachineType = MachineType.AssemblyLine;
+    const parts = [
+      {name: AssemblyLinePart.AlignmentAccuracy, value: 0.5},
+      {name: AssemblyLinePart.BeltSpeed, value: 1.5},
+      {name: AssemblyLinePart.FittingTolerance, value: 0.025},
+      {name: AssemblyLinePart.Speed, value: 1.5}
+    ];
+    const expectedHealth = 78.99305555555556;
+
+    const result = calculateMachineHealth(machineName, parts);
+    expect(result).toBe(expectedHealth);
+  });
+});
+
+describe('calculatePartHealth for AssemblyLine', () => {
+  it('calculates part health correctly', () => {
+    const machineName: MachineType = MachineType.QualityControlStation;
+    const part: partInfo = {name: QualityControlStationPart.CameraCalibration, value: 0.5};
+    const expectedHealth = 75;
+
+    const result = calculatePartHealth(machineName, part);
+    expect(result).toBe(expectedHealth);
+  });
+});
+
+describe('calculateMachineHealth for AssemblyLine', () => {
+  it('calculates machine health correctly', () => {
+    const machineName: MachineType = MachineType.QualityControlStation;
+    const parts = [
+      {name: QualityControlStationPart.CameraCalibration, value: 0.5},
+      {name: QualityControlStationPart.CriteriaSettings, value: 0.5},
+      {name: QualityControlStationPart.LightIntensity, value: 91.5},
+      /*{name: QualityControlStationPart.SoftwareVersion, value: 'v2.0'}
+        Bug? Find out how strings should be handled
+      */  
+    ];
+    const expectedHealth = 71.66666666666667;
 
     const result = calculateMachineHealth(machineName, parts);
     expect(result).toBe(expectedHealth);

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,7 @@
   "author": "BellSant",
   "dependencies": {
     "@netlify/functions": "^2.0.2",
-    "express": "^4.17.1",
+    "express": "^4.18.2",
     "serverless-http": "^3.2.0",
     "typescript": "^5.2.2"
   },

--- a/native-app/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/native-app/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<Text
+  style={
+    [
+      {
+        "color": "#000",
+      },
+      [
+        undefined,
+        {
+          "fontFamily": "SpaceMono",
+        },
+      ],
+    ]
+  }
+>
+  Snapshot test!
+</Text>
+`;

--- a/native-app/package.json
+++ b/native-app/package.json
@@ -12,13 +12,28 @@
   "jest": {
     "preset": "jest-expo"
   },
+  "detox": {
+    "testRunner": "jest",
+    "configurations": {
+      "android.emu.debug": {
+        "type": "android.emulator",
+        "binaryPath": "../MachineHealth.apk",
+        "build": "cd android && ./gradlew assembleDebug && cd ..",
+        "device": {
+          "avdName": "Pixel_2_API_29"
+        }
+      }
+    }
+  },
+  "testTimeout": 120000,
   "dependencies": {
     "@expo/vector-icons": "^13.0.0",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-community/picker": "^1.8.1",
     "@react-navigation/native": "^6.0.2",
     "axios": "^1.5.0",
-    "expo": "~49.0.11",
+    "detox": "^20.12.1",
+    "expo": "^49.0.11",
     "expo-font": "~11.4.0",
     "expo-linking": "~5.0.2",
     "expo-router": "^2.0.0",


### PR DESCRIPTION
**API/Unit:**
My check-in is for expanding the api tests only. I added coverage to the remaining machine type. If I had additional time, I would parse the machine.json file to dynamically get values and create a function that calculates the expected value. This way we're not testing with static values each time.

**Integration/e2e:**
I'm stuck on on the integration tests setup. I used ChatGPT to get instructions to setup a Jest framework (first timer) with Detox.

**Regression Strategy:**
Run API/Unit tests per code check-in/per day (whatever works best for the team). I'd exhaust testing here (test run fast, validate business logic). Integration/e2e tests would run less frequently: daily smoke tests to ensure core feature sets, followed by full regression test suite once there's a viable release candidate.